### PR TITLE
Fix bug in OAuth window

### DIFF
--- a/src/app/services/authentication.ts
+++ b/src/app/services/authentication.ts
@@ -52,7 +52,7 @@ export class Authentication {
     // Build the OAuth consent page URL
     let githubUrl = 'https://github.com/login/oauth/authorize?';
     let authUrl = githubUrl + 'client_id=' + options.github.client_id + '&scope=' + options.github.scopes;
-    this.authWindow.loadUrl(authUrl);
+    this.authWindow.loadURL(authUrl);
     this.authWindow.show();
 
     // Handle the response from GitHub


### PR DESCRIPTION
The method 'BrowserWindow.loadUrl' should be called 'BrowserWindow.loadURL'.