### PR TITLE
removed webpack-target-electron-renderer

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,6 @@ const helpers = require('./helpers');
 const path = require('path');
 
 var CopyWebpackPlugin = require('copy-webpack-plugin');
-const webpackTargetElectronRenderer = require('webpack-target-electron-renderer');
 const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
 
 /*
@@ -147,5 +146,5 @@ var config = {
 /**
  * Target Electron
  */
-config.target = webpackTargetElectronRenderer(config);
+config.target = 'electron-renderer';
 module.exports = config;


### PR DESCRIPTION
Hi Joao,
as discussed in the issue https://github.com/joaogarin/angular2-electron/issues/46 have made changes in the webpack config for electron renderer.

Thanks
Suresh Nagar.
