### PR TITLE
Update material 2 styles prefixes

### DIFF
--- a/src/app/components/app.theme.scss
+++ b/src/app/components/app.theme.scss
@@ -2,25 +2,25 @@
 
 // NOTE: Theming is currently experimental and not yet publically released!
 
-@include md-core();
+@include mat-core();
 
 //Here the existing theme is being redfined
-$primary: md-palette($md-deep-purple);
-$accent:  md-palette($md-amber, A200, A100, A400);
+$primary: mat-palette($mat-deep-purple);
+$accent:  mat-palette($mat-amber, A200, A100, A400);
 
-$theme: md-light-theme($primary, $accent);
+$theme: mat-light-theme($primary, $accent);
 
 @include angular-material-theme($theme);
 
 // This is where you define your custom them
 
-// md-palette takes, color, default, lighter and darker params
+// mat-palette takes, color, default, lighter and darker params
 .m2app-dark {
-  $dark-primary: md-palette($md-cyan, 700, 500, 900);
-  $dark-accent:  md-palette($md-yellow, A200, A100, A400);
-  $dark-warn:    md-palette($md-amber, A200, A100, A400);
+  $dark-primary: mat-palette($mat-cyan, 700, 500, 900);
+  $dark-accent:  mat-palette($mat-yellow, A200, A100, A400);
+  $dark-warn:    mat-palette($mat-amber, A200, A100, A400);
 
-  $dark-theme: md-dark-theme($dark-primary, $dark-accent, $dark-warn);
+  $dark-theme: mat-dark-theme($dark-primary, $dark-accent, $dark-warn);
 
   @include angular-material-theme($dark-theme);
 }


### PR DESCRIPTION
according to pull request https://github.com/angular/material2/pull/2790 all "md-" changed to "mat-"