### PR TITLE
Move main.js to root folder

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,7 +19,7 @@ const createWindow = () => {
   mainWindow = new BrowserWindow({ width: 1200, height: 900 });
 
   // Tell Electron where to load the entry point from
-  mainWindow.loadURL('file://' + __dirname + '/index.html');
+  mainWindow.loadURL('file://' + __dirname + '/src/app/index.html');
 
   // Open the DevTools.
   mainWindow.webContents.openDevTools();

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular2-electron",
   "version": "0.0.0",
   "description": "Angular 2 with Electron and Webpack",
-  "main": "",
+  "main": "main.js",
   "scripts": {
     "watch": "npm run watch:dev",
     "watch:dev": "webpack --watch --progress --profile",
@@ -10,7 +10,7 @@
     "build:dev": "webpack --progress --profile",
     "package": "node package.js",
     "package-all": "npm run package -- --all",
-    "electron": "electron src/app",
+    "electron": "electron .",
     "webpack-test": "webpack --config webpack.test.js --progress --profile",
     "test": "karma start"
   },


### PR DESCRIPTION
When people inevitably want to package the electron app, they will have problems if `main.js` is not in the same folder as `node_modules`.

Therefore, move `main.js` to root folder, and update `mainWindow.loadURL()` to use the new relative location of `index.html`.

See [this issue with electron package manager not bundling node_modules](https://github.com/electron-userland/electron-packager/issues/527). It was leaving the `node_modules` in the output folder empty, when it should have been bundling the ones used by the application.

It's kind of a quiet problem until you create a Windows installer, because the exe in the output folder will run with the `node_modules` from the ancestor `node_modules` folder, but there will be no `node_modules` bundled.